### PR TITLE
Remove Medium links from site social menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,6 @@
       <div class="header-social-links">
         <a href="mailto:mikitoyota38@gmail.com"><i class="bi bi-envelope"></i></a>
         <a href="https://jp.linkedin.com/in/miki-toyota" class="linkedin"><i class="bi bi-linkedin"></i></a>
-        <a href="https://medium.com/@mikitoyota" class="medium"><i class="bi bi-medium"></i></a>
         <a href="https://mikitoyota.substack.com" class="substack"><i class="bi bi-substack"></i></a>
       </div>
 
@@ -910,7 +909,6 @@
             <div class="social-links d-flex">
               <a href="mailto:mikitoyota38@gmail.com"><i class="bi bi-envelope"></i></a>
               <a href="https://jp.linkedin.com/in/miki-toyota"><i class="bi bi-linkedin"></i></a>
-              <a href="https://medium.com/@mikitoyota"><i class="bi bi-medium"></i></a>
               <a href="https://mikitoyota.substack.com"><i class="bi bi-substack"></i></a>
             </div>
             <p class="lead">Let’s chat and make great things happen.</p>


### PR DESCRIPTION
## Summary
- remove the Medium social link from the header navigation icons
- remove the Medium icon and link from the "Let's Connect" section at the bottom of the page

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cf54a55c208322bb351dfc3b7c57ba