### PR TITLE
Update market entry service content

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,8 +814,12 @@
               <div class="col-md-6" data-aos="fade-up" data-aos-delay="200">
                 <div class="service-item">
               <i class="bi bi-globe2 icon"></i>
-                  <h3><a href="#heroexit">Cross-Cultural Brand Strategy</a></h3>
-                  <p>Craft messaging that resonates across cultural and linguistic boundaries. Align your brand with local values to build lasting trust.</p>
+                  <h3><a href="#heroexit">Market Entry &amp; Messaging Strategy</a></h3>
+                  <ul class="mb-0">
+                    <li>Roadmapping for Japan market entry or expansion with actionable next steps</li>
+                    <li>Cultural audits + competitor analysis based on local buyer behavior</li>
+                    <li>Go-to-market storytelling aligned with Japan’s tone, pacing, and trust expectations</li>
+                  </ul>
                 </div>
               </div><!-- End Service Item -->
 


### PR DESCRIPTION
## Summary
- rename the "Cross-Cultural Brand Strategy" service card to "Market Entry & Messaging Strategy"
- replace the paragraph content with a bulleted list covering market entry roadmapping, cultural audits, and go-to-market storytelling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf577600d883229a20df8ab2262c1b