### PR TITLE
Add accordion interaction to Services section

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1443,47 +1443,124 @@ section,
   color: var(--contrast-color);
 }
 
-.services .service-item {
-  background-color: var(--surface-color);
-  padding: 30px;
-  border-radius: 10px;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-  height: 100%;
-  transition: transform 0.3s ease;
+.services .services-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-.services .service-item ul {
-  font-size: 0.9rem;
-  color: color-mix(in srgb, var(--default-color), transparent 25%);
+.services .service-accordion-item {
+  background: color-mix(in srgb, var(--surface-color) 92%, transparent 8%);
+  border: 1px solid color-mix(in srgb, var(--default-color), transparent 80%);
+  border-radius: 18px;
+  box-shadow: 0 24px 40px -32px rgba(12, 20, 30, 0.45);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+  overflow: hidden;
 }
 
-.services .service-item:hover {
-  transform: scale(1.05);
+.services .service-accordion-item.is-open {
+  border-color: color-mix(in srgb, var(--accent-color) 65%, transparent 35%);
+  box-shadow: 0 28px 60px -28px rgba(15, 25, 35, 0.55);
+  transform: translateY(-2px);
 }
 
-.services .service-item i {
-  font-size: 2.5rem;
-  color: var(--accent-color);
-  display: inline-block;
-  margin-bottom: 15px;
-}
-
-.services .service-item h3 {
-  font-size: 1.25rem;
-  margin-bottom: 15px;
-}
-
-.services .service-item h3 a {
+.services .service-accordion-header {
+  align-items: center;
+  background: transparent;
+  border: 0;
   color: var(--heading-color);
+  cursor: pointer;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1.5rem 1.75rem;
+  position: relative;
+  text-align: left;
+  width: 100%;
+  font-size: 1.1rem;
+  font-weight: 600;
+  transition: color 0.3s ease;
 }
 
-.services .service-item h3 a:hover {
+.services .service-accordion-header:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent-color) 60%, transparent 40%);
+  outline-offset: 4px;
+}
+
+.services .service-accordion-summary {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}
+
+.services .service-accordion-header .icon {
+  font-size: 2rem;
+  color: color-mix(in srgb, var(--accent-color) 80%, var(--heading-color) 20%);
+  transition: color 0.3s ease;
+}
+
+.services .service-accordion-title {
+  line-height: 1.4;
+}
+
+.services .service-accordion-indicator {
+  align-items: center;
+  color: color-mix(in srgb, var(--default-color), transparent 25%);
+  display: inline-flex;
+  font-size: 1.25rem;
+  height: 2rem;
+  justify-content: center;
+  transition: transform 0.3s ease, color 0.3s ease;
+  width: 2rem;
+}
+
+.services .service-accordion-item.is-open .service-accordion-indicator {
+  transform: rotate(180deg);
   color: var(--accent-color);
 }
 
-.services .service-item p {
-  font-size: 0.9rem;
-  color: color-mix(in srgb, var(--default-color), transparent 25%);
+.services .service-accordion-item.is-open .service-accordion-header .icon {
+  color: var(--accent-color);
+}
+
+.services .service-accordion-header:hover .service-accordion-title {
+  color: var(--accent-color);
+}
+
+.services .service-accordion-content {
+  border-top: 1px solid color-mix(in srgb, var(--default-color), transparent 85%);
+  padding: 0 1.75rem 1.75rem;
+  animation: accordionFade 0.25s ease;
+}
+
+.services .service-accordion-list {
+  color: color-mix(in srgb, var(--default-color), transparent 15%);
+  display: grid;
+  font-size: 0.95rem;
+  gap: 0.75rem;
+  margin: 1.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+@keyframes accordionFade {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 575px) {
+  .services .service-accordion-header {
+    padding: 1.25rem 1.25rem;
+  }
+
+  .services .service-accordion-content {
+    padding: 0 1.25rem 1.25rem;
+  }
 }
 
 @media (max-width: 991px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -180,6 +180,53 @@
   });
 
   /**
+   * Services accordion interaction
+   */
+  const serviceAccordionItems = document.querySelectorAll('.service-accordion-item');
+
+  const closeServiceItem = (item) => {
+    const header = item.querySelector('.service-accordion-header');
+    const content = item.querySelector('.service-accordion-content');
+    if (!header || !content) return;
+    header.setAttribute('aria-expanded', 'false');
+    content.setAttribute('hidden', '');
+    item.classList.remove('is-open');
+  };
+
+  const openServiceItem = (item) => {
+    const header = item.querySelector('.service-accordion-header');
+    const content = item.querySelector('.service-accordion-content');
+    if (!header || !content) return;
+    header.setAttribute('aria-expanded', 'true');
+    content.removeAttribute('hidden');
+    item.classList.add('is-open');
+  };
+
+  if (serviceAccordionItems.length) {
+    serviceAccordionItems.forEach((item) => {
+      const header = item.querySelector('.service-accordion-header');
+      const content = item.querySelector('.service-accordion-content');
+      if (!header || !content) return;
+
+      header.addEventListener('click', () => {
+        const isOpen = header.getAttribute('aria-expanded') === 'true';
+
+        serviceAccordionItems.forEach((accordionItem) => {
+          if (accordionItem !== item) {
+            closeServiceItem(accordionItem);
+          }
+        });
+
+        if (isOpen) {
+          closeServiceItem(item);
+        } else {
+          openServiceItem(item);
+        }
+      });
+    });
+  }
+
+  /**
    * Correct scrolling position upon page load for URLs containing hash links.
    */
   window.addEventListener('load', function(e) {

--- a/index.html
+++ b/index.html
@@ -211,69 +211,92 @@
 
       <div class="container" data-aos="fade-up" data-aos-delay="100">
 
-        <div class="row align-items-center">
+        <div class="services-accordion" role="list">
 
-          <div>
-            <div class="row g-4">
-
-              <div class="col-md-6" data-aos="fade-up" data-aos-delay="200">
-                <div class="service-item">
-              <i class="bi bi-globe2 icon"></i>
-                  <h3><a href="#heroexit">Market Entry &amp; Messaging Strategy</a></h3>
-                  <ul class="mb-0">
-                    <li>Roadmapping for Japan market entry or expansion with actionable next steps</li>
-                    <li>Cultural audits + competitor analysis based on local buyer behavior</li>
-                    <li>Go-to-market storytelling aligned with Japan’s tone, pacing, and trust expectations</li>
-                  </ul>
-                </div>
-              </div><!-- End Service Item -->
-
-              <div class="col-md-6" data-aos="fade-up" data-aos-delay="300">
-                <div class="service-item">
-              <i class="bi bi-pencil-square icon"></i>
-                  <h3><a href="#heroexit">Multilingual Copywriting & Editing</a></h3>
-                  <ul class="mb-0">
-                    <li>Website, landing page, and product copy localization</li>
-                    <li>Bilingual brand guidelines to unify tone and style across all touchpoints</li>
-                    <li>Messaging playbooks for global ⇄ JP team alignment</li>
-                    <li>SEO-adapted Japanese content optimized for search and audience behavior</li>
-                    <li>UX and microcopy localization that builds trust and improves usability</li>
-                    <li>Japanese social media content and strategy</li>
-                    <li>Email marketing and community engagement</li>
-                    <li>Paid ad localization (Google, Meta, Line, etc.)</li>
-                    <li>Bilingual press kits, releases, and media rewrites for Japan-facing PR</li>
-                  </ul>
-                </div>
-              </div><!-- End Service Item -->
-
-              <div class="col-md-6" data-aos="fade-up" data-aos-delay="400">
-                <div class="service-item">
-              <i class="bi bi-book-half icon"></i>
-                  <h3><a href="#heroexit">Live Interpretation & Offline Activation</a></h3>
-                  <ul>
-                    <li>EN ⇄ JP interpreting for investor meetings, cross-border strategy calls, and client negotiations</li>
-                    <li>Event scripting, bilingual MC support, and local staff coordination</li>
-                    <li>Local community outreach and vendor coordination</li>
-                    <li>Presentation and investor deck support</li>
-                  </ul>
-                </div>
-              </div><!-- End Service Item -->
-
-              <div class="col-md-6" data-aos="fade-up" data-aos-delay="500">
-                <div class="service-item">
-              <i class="bi bi-signpost-2-fill icon"></i>
-                  <h3><a href="#heroexit">User Research & Cultural Insight</a></h3>
-                  <ul>
-                    <li>Persona development for Japanese users and decision-makers</li>
-                    <li>Bilingual interviews & moderated feedback sessions</li>
-                    <li>UX and content usability testing in local context</li>
-                    <li>Interview synthesis and insight mapping</li>
-                  </ul>
-                </div>
-              </div><!-- End Service Item -->
-
+          <div class="service-accordion-item" data-aos="fade-up" data-aos-delay="0">
+            <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-1">
+              <span class="service-accordion-summary">
+                <i class="bi bi-globe2 icon" aria-hidden="true"></i>
+                <span class="service-accordion-title">Market Entry &amp; Messaging Strategy</span>
+              </span>
+              <span class="service-accordion-indicator" aria-hidden="true">
+                <i class="bi bi-chevron-down"></i>
+              </span>
+            </button>
+            <div class="service-accordion-content" id="service-panel-1" hidden>
+              <ul class="service-accordion-list">
+                <li>Roadmapping for Japan market entry or expansion with actionable next steps</li>
+                <li>Cultural audits + competitor analysis based on local buyer behavior</li>
+                <li>Go-to-market storytelling aligned with Japan’s tone, pacing, and trust expectations</li>
+              </ul>
             </div>
-          </div>
+          </div><!-- End Service Item -->
+
+          <div class="service-accordion-item" data-aos="fade-up" data-aos-delay="100">
+            <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-2">
+              <span class="service-accordion-summary">
+                <i class="bi bi-pencil-square icon" aria-hidden="true"></i>
+                <span class="service-accordion-title">Multilingual Copywriting &amp; Editing</span>
+              </span>
+              <span class="service-accordion-indicator" aria-hidden="true">
+                <i class="bi bi-chevron-down"></i>
+              </span>
+            </button>
+            <div class="service-accordion-content" id="service-panel-2" hidden>
+              <ul class="service-accordion-list">
+                <li>Website, landing page, and product copy localization</li>
+                <li>Bilingual brand guidelines to unify tone and style across all touchpoints</li>
+                <li>Messaging playbooks for global ⇄ JP team alignment</li>
+                <li>SEO-adapted Japanese content optimized for search and audience behavior</li>
+                <li>UX and microcopy localization that builds trust and improves usability</li>
+                <li>Japanese social media content and strategy</li>
+                <li>Email marketing and community engagement</li>
+                <li>Paid ad localization (Google, Meta, Line, etc.)</li>
+                <li>Bilingual press kits, releases, and media rewrites for Japan-facing PR</li>
+              </ul>
+            </div>
+          </div><!-- End Service Item -->
+
+          <div class="service-accordion-item" data-aos="fade-up" data-aos-delay="200">
+            <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-3">
+              <span class="service-accordion-summary">
+                <i class="bi bi-book-half icon" aria-hidden="true"></i>
+                <span class="service-accordion-title">Live Interpretation &amp; Offline Activation</span>
+              </span>
+              <span class="service-accordion-indicator" aria-hidden="true">
+                <i class="bi bi-chevron-down"></i>
+              </span>
+            </button>
+            <div class="service-accordion-content" id="service-panel-3" hidden>
+              <ul class="service-accordion-list">
+                <li>EN ⇄ JP interpreting for investor meetings, cross-border strategy calls, and client negotiations</li>
+                <li>Event scripting, bilingual MC support, and local staff coordination</li>
+                <li>Local community outreach and vendor coordination</li>
+                <li>Presentation and investor deck support</li>
+              </ul>
+            </div>
+          </div><!-- End Service Item -->
+
+          <div class="service-accordion-item" data-aos="fade-up" data-aos-delay="300">
+            <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-4">
+              <span class="service-accordion-summary">
+                <i class="bi bi-signpost-2-fill icon" aria-hidden="true"></i>
+                <span class="service-accordion-title">User Research &amp; Cultural Insight</span>
+              </span>
+              <span class="service-accordion-indicator" aria-hidden="true">
+                <i class="bi bi-chevron-down"></i>
+              </span>
+            </button>
+            <div class="service-accordion-content" id="service-panel-4" hidden>
+              <ul class="service-accordion-list">
+                <li>Persona development for Japanese users and decision-makers</li>
+                <li>Bilingual interviews &amp; moderated feedback sessions</li>
+                <li>UX and content usability testing in local context</li>
+                <li>Interview synthesis and insight mapping</li>
+              </ul>
+            </div>
+          </div><!-- End Service Item -->
+
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- convert the Services section into an accordion that hides details until expanded
- style the accordion with a clean, modern appearance consistent with the site
- add JavaScript to drive the toggle behaviour and ensure only one panel is open at a time

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf9878ee288322916efb39bb222bca