### PR TITLE
Update services copy and typography

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1417,6 +1417,22 @@ section,
   gap: 1.5rem;
 }
 
+.services .section-title h2 {
+  font-family: "Merriweather", serif;
+  font-size: clamp(2.5rem, 5vw + 1rem, 4.5rem);
+  font-weight: 700;
+  line-height: 1.22;
+  letter-spacing: -0.01em;
+  color: var(--default-color);
+}
+
+.services .section-title p {
+  font-family: "Open Sans", sans-serif;
+  font-size: 1.03125rem;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--default-color), transparent 10%);
+}
+
 .services .service-accordion-item {
   background: color-mix(in srgb, var(--surface-color) 92%, transparent 8%);
   border: 1px solid color-mix(in srgb, var(--default-color), transparent 80%);
@@ -1433,20 +1449,22 @@ section,
 }
 
 .services .service-accordion-header {
-  align-items: center;
+  align-items: flex-start;
   background: transparent;
   border: 0;
-  color: var(--heading-color);
+  color: var(--default-color);
   cursor: pointer;
   display: flex;
-  gap: 1rem;
+  gap: 1.5rem;
   justify-content: space-between;
-  padding: 1.5rem 1.75rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
   position: relative;
   text-align: left;
   width: 100%;
-  font-size: 1.1rem;
-  font-weight: 600;
+  font-family: "Merriweather", serif;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
   transition: color 0.3s ease;
 }
 
@@ -1456,19 +1474,25 @@ section,
 }
 
 .services .service-accordion-summary {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   gap: 1rem;
+  flex: 1;
 }
 
 .services .service-accordion-header .icon {
-  font-size: 2rem;
+  font-size: 1.5rem;
   color: color-mix(in srgb, var(--accent-color) 80%, var(--heading-color) 20%);
   transition: color 0.3s ease;
+  margin-top: 0.4rem;
 }
 
 .services .service-accordion-title {
-  line-height: 1.4;
+  font-family: "Merriweather", serif;
+  font-size: clamp(2.25rem, 4vw + 1.25rem, 4.5rem);
+  font-weight: 700;
+  line-height: 1.24;
+  letter-spacing: -0.01em;
 }
 
 .services .service-accordion-indicator {
@@ -1480,6 +1504,7 @@ section,
   justify-content: center;
   transition: transform 0.3s ease, color 0.3s ease;
   width: 2rem;
+  margin-top: 0.75rem;
 }
 
 .services .service-accordion-item.is-open .service-accordion-indicator {
@@ -1497,17 +1522,38 @@ section,
 
 .services .service-accordion-content {
   border-top: 1px solid color-mix(in srgb, var(--default-color), transparent 85%);
-  padding: 0 1.75rem 1.75rem;
+  padding: 0 clamp(1.5rem, 3vw, 2.25rem) clamp(1.5rem, 3vw, 2.25rem);
   animation: accordionFade 0.25s ease;
+  font-family: "Open Sans", sans-serif;
 }
 
 .services .service-accordion-list {
-  color: color-mix(in srgb, var(--default-color), transparent 15%);
+  color: color-mix(in srgb, var(--default-color), transparent 5%);
   display: grid;
-  font-size: 0.95rem;
-  gap: 0.75rem;
-  margin: 1.5rem 0 0;
-  padding-left: 1.25rem;
+  font-family: "Open Sans", sans-serif;
+  font-size: 1.03125rem;
+  gap: 1rem;
+  line-height: 1.5;
+  margin: 1.75rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.services .service-accordion-list li {
+  position: relative;
+  padding-left: 2rem;
+}
+
+.services .service-accordion-list li::before {
+  content: "\203A";
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  font-family: "Merriweather", serif;
+  font-size: 1.45rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #e24c39;
 }
 
 @keyframes accordionFade {
@@ -1524,16 +1570,42 @@ section,
 @media (max-width: 575px) {
   .services .service-accordion-header {
     padding: 1.25rem 1.25rem;
+    gap: 1rem;
   }
 
   .services .service-accordion-content {
     padding: 0 1.25rem 1.25rem;
   }
+
+  .services .service-accordion-title {
+    font-size: clamp(1.85rem, 8vw, 3.1rem);
+  }
+
+  .services .service-accordion-indicator {
+    margin-top: 0.5rem;
+  }
+
+  .services .service-accordion-list {
+    margin-top: 1.5rem;
+    gap: 0.85rem;
+  }
+
+  .services .service-accordion-list li {
+    padding-left: 1.5rem;
+  }
+
+  .services .service-accordion-list li::before {
+    font-size: 1.2rem;
+  }
 }
 
 @media (max-width: 991px) {
-  .services h2 {
-    font-size: 2rem;
+  .services .section-title h2 {
+    font-size: clamp(2.15rem, 5vw + 1rem, 3.75rem);
+  }
+
+  .services .service-accordion-title {
+    font-size: clamp(2rem, 4.5vw + 1.25rem, 3.75rem);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -30,10 +30,12 @@
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" as="style">
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap" as="style">
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Questrial&display=swap" as="style">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" as="style">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" as="style">
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Style+Script&display=swap" as="style">
   <link href="https://fonts.googleapis.com" rel="preconnect">
   <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Questrial:wght@400&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Questrial:wght@400&family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Style+Script&display=swap" rel="stylesheet">
  
   <!-- Vendor CSS Files -->
@@ -203,7 +205,7 @@
             <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-1">
               <span class="service-accordion-summary">
                 <i class="bi bi-globe2 icon" aria-hidden="true"></i>
-                <span class="service-accordion-title">Market Entry &amp; Messaging Strategy</span>
+                <span class="service-accordion-title">Strategy &amp; Market Entry</span>
               </span>
               <span class="service-accordion-indicator" aria-hidden="true">
                 <i class="bi bi-chevron-down"></i>
@@ -211,9 +213,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-1" hidden>
               <ul class="service-accordion-list">
-                <li>Roadmapping for Japan market entry or expansion with actionable next steps</li>
-                <li>Cultural audits + competitor analysis based on local buyer behavior</li>
-                <li>Go-to-market storytelling aligned with Japan’s tone, pacing, and trust expectations</li>
+                <li>Direction — Go-to-market strategy and roadmaps for Japan entry or expansion</li>
+                <li>Insight — Cultural audits + competitor analysis tied to real buyer behavior</li>
+                <li>Storytelling — Messaging + channel strategy aligned with Japan’s high-trust market dynamics</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -222,7 +224,7 @@
             <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-2">
               <span class="service-accordion-summary">
                 <i class="bi bi-pencil-square icon" aria-hidden="true"></i>
-                <span class="service-accordion-title">Multilingual Copywriting &amp; Editing</span>
+                <span class="service-accordion-title">Content &amp; Campaign Localization</span>
               </span>
               <span class="service-accordion-indicator" aria-hidden="true">
                 <i class="bi bi-chevron-down"></i>
@@ -230,15 +232,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-2" hidden>
               <ul class="service-accordion-list">
-                <li>Website, landing page, and product copy localization</li>
-                <li>Bilingual brand guidelines to unify tone and style across all touchpoints</li>
-                <li>Messaging playbooks for global ⇄ JP team alignment</li>
-                <li>SEO-adapted Japanese content optimized for search and audience behavior</li>
-                <li>UX and microcopy localization that builds trust and improves usability</li>
-                <li>Japanese social media content and strategy</li>
-                <li>Email marketing and community engagement</li>
-                <li>Paid ad localization (Google, Meta, Line, etc.)</li>
-                <li>Bilingual press kits, releases, and media rewrites for Japan-facing PR</li>
+                <li>Resonate — Website, landing page, and product copy that feels natural &amp; persuasive</li>
+                <li>Unify — Bilingual brand guidelines + messaging playbooks for global ⇄ JP alignment</li>
+                <li>Perform — SEO content, PR, ads, and social campaigns adapted for Japan</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -247,7 +243,7 @@
             <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-3">
               <span class="service-accordion-summary">
                 <i class="bi bi-book-half icon" aria-hidden="true"></i>
-                <span class="service-accordion-title">Live Interpretation &amp; Offline Activation</span>
+                <span class="service-accordion-title">Interpretation &amp; Activation</span>
               </span>
               <span class="service-accordion-indicator" aria-hidden="true">
                 <i class="bi bi-chevron-down"></i>
@@ -255,10 +251,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-3" hidden>
               <ul class="service-accordion-list">
-                <li>EN ⇄ JP interpreting for investor meetings, cross-border strategy calls, and client negotiations</li>
-                <li>Event scripting, bilingual MC support, and local staff coordination</li>
-                <li>Local community outreach and vendor coordination</li>
-                <li>Presentation and investor deck support</li>
+                <li>Connect — EN ⇄ JP interpreting for investor meetings, community engagement, and client negotiations</li>
+                <li>Engage — Event scripting, bilingual MC support, and local staff/vendor coordination</li>
+                <li>Activate — On-the-ground brand activations, outreach, and live presence that build trust with Japanese audiences</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -267,7 +262,7 @@
             <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-4">
               <span class="service-accordion-summary">
                 <i class="bi bi-signpost-2-fill icon" aria-hidden="true"></i>
-                <span class="service-accordion-title">User Research &amp; Cultural Insight</span>
+                <span class="service-accordion-title">User Research &amp; Japanese Market Insight</span>
               </span>
               <span class="service-accordion-indicator" aria-hidden="true">
                 <i class="bi bi-chevron-down"></i>
@@ -275,10 +270,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-4" hidden>
               <ul class="service-accordion-list">
-                <li>Persona development for Japanese users and decision-makers</li>
-                <li>Bilingual interviews &amp; moderated feedback sessions</li>
-                <li>UX and content usability testing in local context</li>
-                <li>Interview synthesis and insight mapping</li>
+                <li>Understand — Build Japanese-specific customer and stakeholder personas reflecting real behaviors and decision-making styles</li>
+                <li>Listen — Bilingual interviews, moderated sessions, and usability testing</li>
+                <li>Map — Research synthesis and cultural insight mapping to guide strategy</li>
               </ul>
             </div>
           </div><!-- End Service Item -->


### PR DESCRIPTION
## Summary
- refresh the Services section copy with the new strategy, localization, activation, and research offerings
- load Merriweather and Open Sans webfonts and apply updated typography guidelines to the Services heading and cards
- restyle service lists with chevron bullets, refined spacing, and responsive sizing for mobile readability

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfce6c5fd88322875a611508614c7d