### PR TITLE
Revamp services typography and tagline

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1419,11 +1419,11 @@ section,
 
 .services .section-title h2 {
   font-family: "Merriweather", serif;
-  font-size: clamp(2.5rem, 5vw + 1rem, 4.5rem);
+  font-size: clamp(36px, 4vw + 1rem, 49px);
   font-weight: 700;
-  line-height: 1.22;
+  line-height: 1.18;
   letter-spacing: -0.01em;
-  color: var(--default-color);
+  color: #667a90;
 }
 
 .services .section-title p {
@@ -1489,9 +1489,9 @@ section,
 
 .services .service-accordion-title {
   font-family: "Merriweather", serif;
-  font-size: clamp(2.25rem, 4vw + 1.25rem, 4.5rem);
+  font-size: clamp(28px, 3.5vw + 1rem, 42px);
   font-weight: 700;
-  line-height: 1.24;
+  line-height: 1.2;
   letter-spacing: -0.01em;
 }
 
@@ -1524,13 +1524,15 @@ section,
   border-top: 1px solid color-mix(in srgb, var(--default-color), transparent 85%);
   padding: 0 clamp(1.5rem, 3vw, 2.25rem) clamp(1.5rem, 3vw, 2.25rem);
   animation: accordionFade 0.25s ease;
-  font-family: "Open Sans", sans-serif;
+  font-family: "Atlas Grotesk", "Open Sans", "Helvetica Neue", Arial, sans-serif;
+  font-size: 1.03125rem;
+  line-height: 1.5;
 }
 
 .services .service-accordion-list {
   color: color-mix(in srgb, var(--default-color), transparent 5%);
   display: grid;
-  font-family: "Open Sans", sans-serif;
+  font-family: "Atlas Grotesk", "Open Sans", "Helvetica Neue", Arial, sans-serif;
   font-size: 1.03125rem;
   gap: 1rem;
   line-height: 1.5;
@@ -1545,12 +1547,12 @@ section,
 }
 
 .services .service-accordion-list li::before {
-  content: "\203A";
+  content: ">";
   position: absolute;
   left: 0;
-  top: 0.15rem;
+  top: 0.2rem;
   font-family: "Merriweather", serif;
-  font-size: 1.45rem;
+  font-size: 1.35rem;
   font-weight: 700;
   line-height: 1;
   color: #e24c39;
@@ -1578,7 +1580,7 @@ section,
   }
 
   .services .service-accordion-title {
-    font-size: clamp(1.85rem, 8vw, 3.1rem);
+    font-size: clamp(26px, 8vw, 36px);
   }
 
   .services .service-accordion-indicator {
@@ -1595,18 +1597,34 @@ section,
   }
 
   .services .service-accordion-list li::before {
-    font-size: 1.2rem;
+    font-size: 1.1rem;
   }
 }
 
 @media (max-width: 991px) {
   .services .section-title h2 {
-    font-size: clamp(2.15rem, 5vw + 1rem, 3.75rem);
+    font-size: clamp(32px, 5vw + 1rem, 42px);
   }
 
   .services .service-accordion-title {
-    font-size: clamp(2rem, 4.5vw + 1.25rem, 3.75rem);
+    font-size: clamp(26px, 4.5vw + 1.25rem, 40px);
   }
+}
+
+.services-tagline {
+  margin: clamp(2.5rem, 6vw, 4rem) auto clamp(3rem, 7vw, 5rem);
+  max-width: 920px;
+  text-align: center;
+  font-family: "Atlas Grotesk", "Open Sans", "Helvetica Neue", Arial, sans-serif;
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.6;
+  color: var(--default-color);
+  padding: 0 1.5rem;
+}
+
+.services-tagline p {
+  margin: 0;
 }
 
 /*--------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -194,7 +194,6 @@
             <path d="M 0,10 C 40,0 60,20 100,10 C 140,0 160,20 200,10" fill="none" stroke="currentColor" stroke-width="2"></path>
           </svg>
         </div>
-        <p>Your brand has a story—let’s make sure it’s heard and understood worldwide.</p>
       </div><!-- End Section Title -->
 
       <div class="container" data-aos="fade-up" data-aos-delay="100">
@@ -213,9 +212,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-1" hidden>
               <ul class="service-accordion-list">
-                <li>Direction — Go-to-market strategy and roadmaps for Japan entry or expansion</li>
-                <li>Insight — Cultural audits + competitor analysis tied to real buyer behavior</li>
-                <li>Storytelling — Messaging + channel strategy aligned with Japan’s high-trust market dynamics</li>
+                <li><strong>Direction</strong> — Go-to-market strategy and roadmaps for Japan entry or expansion</li>
+                <li><strong>Insight</strong> — Cultural audits + competitor analysis tied to real buyer behavior</li>
+                <li><strong>Storytelling</strong> — Messaging + channel strategy aligned with Japan’s high-trust market dynamics</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -232,9 +231,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-2" hidden>
               <ul class="service-accordion-list">
-                <li>Resonate — Website, landing page, and product copy that feels natural &amp; persuasive</li>
-                <li>Unify — Bilingual brand guidelines + messaging playbooks for global ⇄ JP alignment</li>
-                <li>Perform — SEO content, PR, ads, and social campaigns adapted for Japan</li>
+                <li><strong>Resonate</strong> — Website, landing page, and product copy that feels natural &amp; persuasive</li>
+                <li><strong>Unify</strong> — Bilingual brand guidelines + messaging playbooks for global ⇄ JP alignment</li>
+                <li><strong>Perform</strong> — SEO content, PR, ads, and social campaigns adapted for Japan</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -251,9 +250,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-3" hidden>
               <ul class="service-accordion-list">
-                <li>Connect — EN ⇄ JP interpreting for investor meetings, community engagement, and client negotiations</li>
-                <li>Engage — Event scripting, bilingual MC support, and local staff/vendor coordination</li>
-                <li>Activate — On-the-ground brand activations, outreach, and live presence that build trust with Japanese audiences</li>
+                <li><strong>Connect</strong> — EN ⇄ JP interpreting for investor meetings, community engagement, and client negotiations</li>
+                <li><strong>Engage</strong> — Event scripting, bilingual MC support, and local staff/vendor coordination</li>
+                <li><strong>Activate</strong> — On-the-ground brand activations, outreach, and live presence that build trust with Japanese audiences</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -262,7 +261,7 @@
             <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-4">
               <span class="service-accordion-summary">
                 <i class="bi bi-signpost-2-fill icon" aria-hidden="true"></i>
-                <span class="service-accordion-title">User Research &amp; Japanese Market Insight</span>
+                <span class="service-accordion-title">User Research &amp; Market Insight</span>
               </span>
               <span class="service-accordion-indicator" aria-hidden="true">
                 <i class="bi bi-chevron-down"></i>
@@ -270,9 +269,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-4" hidden>
               <ul class="service-accordion-list">
-                <li>Understand — Build Japanese-specific customer and stakeholder personas reflecting real behaviors and decision-making styles</li>
-                <li>Listen — Bilingual interviews, moderated sessions, and usability testing</li>
-                <li>Map — Research synthesis and cultural insight mapping to guide strategy</li>
+                <li><strong>Understand</strong> — Build Japanese-specific customer and stakeholder personas reflecting real behaviors and decision-making styles</li>
+                <li><strong>Listen</strong> — Bilingual interviews, moderated sessions, and usability testing</li>
+                <li><strong>Map</strong> — Research synthesis and cultural insight mapping to guide strategy</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -282,6 +281,10 @@
       </div>
 
     </section><!-- /Services Section -->
+
+    <div class="services-tagline" data-aos="fade-up">
+      <p><strong>Brand clarity. Local credibility. One partner for strategy, localization, and execution.</strong></p>
+    </div>
 
     <!-- About Section -->
     <section id="about" class="about section light-background">


### PR DESCRIPTION
## Summary
- restyle the Services heading, block titles, and body copy to match the requested Merriweather and Atlas Grotesk typography
- bold the lead keywords in each service bullet, update the research service title, and refresh the chevron bullet styling
- replace the legacy Services tagline with the new message centered beneath the section

## Testing
- no automated tests were run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68cfd887184c8322808db5404d6cdd97