### PR TITLE
Refine services tagline placement and typography

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1489,10 +1489,11 @@ section,
 
 .services .service-accordion-title {
   font-family: "Merriweather", serif;
-  font-size: clamp(28px, 3.5vw + 1rem, 42px);
+  font-size: 41px;
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: -0.01em;
+  color: #667a90;
 }
 
 .services .service-accordion-indicator {
@@ -1580,7 +1581,7 @@ section,
   }
 
   .services .service-accordion-title {
-    font-size: clamp(26px, 8vw, 36px);
+    font-size: clamp(28px, 7.5vw, 34px);
   }
 
   .services .service-accordion-indicator {
@@ -1607,24 +1608,20 @@ section,
   }
 
   .services .service-accordion-title {
-    font-size: clamp(26px, 4.5vw + 1.25rem, 40px);
+    font-size: clamp(30px, 4.5vw, 38px);
   }
 }
 
-.services-tagline {
-  margin: clamp(2.5rem, 6vw, 4rem) auto clamp(3rem, 7vw, 5rem);
-  max-width: 920px;
+.services .section-title .services-tagline {
+  margin: clamp(1.25rem, 3.5vw, 1.85rem) auto 0;
+  max-width: clamp(280px, 82vw, 880px);
   text-align: center;
   font-family: "Atlas Grotesk", "Open Sans", "Helvetica Neue", Arial, sans-serif;
   font-size: 17px;
   font-weight: 700;
-  line-height: 1.6;
-  color: var(--default-color);
-  padding: 0 1.5rem;
-}
-
-.services-tagline p {
-  margin: 0;
+  line-height: 1.55;
+  color: #667a90;
+  padding: 0 clamp(1rem, 3vw, 1.5rem);
 }
 
 /*--------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
             <path d="M 0,10 C 40,0 60,20 100,10 C 140,0 160,20 200,10" fill="none" stroke="currentColor" stroke-width="2"></path>
           </svg>
         </div>
+        <p class="services-tagline" data-aos="fade-up" data-aos-delay="50">Brand clarity. Local credibility. One partner for strategy, localization, and execution.</p>
       </div><!-- End Section Title -->
 
       <div class="container" data-aos="fade-up" data-aos-delay="100">
@@ -281,10 +282,6 @@
       </div>
 
     </section><!-- /Services Section -->
-
-    <div class="services-tagline" data-aos="fade-up">
-      <p><strong>Brand clarity. Local credibility. One partner for strategy, localization, and execution.</strong></p>
-    </div>
 
     <!-- About Section -->
     <section id="about" class="about section light-background">


### PR DESCRIPTION
## Summary
- relocate the services tagline directly beneath the section heading underline and style it in bold 17px Atlas Grotesk for consistent emphasis
- set each service accordion title to 41px Merriweather with the #667A90 palette while keeping responsive scaling on smaller screens
- adjust tagline styling to align and scale cleanly within the section title container across viewports

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cfdce452148322a513d265154e2bd9