### PR TITLE
Update services section styling and content

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1559,6 +1559,16 @@ section,
   color: #e24c39;
 }
 
+.services .service-accordion-list .service-keyword-primary {
+  font-weight: 700;
+  color: #000000;
+}
+
+.services .service-accordion-list .service-keyword-secondary {
+  font-weight: 700;
+  color: #667A90;
+}
+
 @keyframes accordionFade {
   from {
     opacity: 0;
@@ -1620,7 +1630,7 @@ section,
   font-size: 17px;
   font-weight: 700;
   line-height: 1.55;
-  color: #667a90;
+  color: #000000;
   padding: 0 clamp(1rem, 3vw, 1.5rem);
 }
 

--- a/index.html
+++ b/index.html
@@ -213,9 +213,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-1" hidden>
               <ul class="service-accordion-list">
-                <li><strong>Direction</strong> — Go-to-market strategy and roadmaps for Japan entry or expansion</li>
-                <li><strong>Insight</strong> — Cultural audits + competitor analysis tied to real buyer behavior</li>
-                <li><strong>Storytelling</strong> — Messaging + channel strategy aligned with Japan’s high-trust market dynamics</li>
+                <li><strong class="service-keyword-primary">Direction</strong> — <strong class="service-keyword-secondary">Go-to-market strategy</strong> and <strong class="service-keyword-secondary">roadmaps</strong> for Japan entry or expansion</li>
+                <li><strong class="service-keyword-primary">Insight</strong> — <strong class="service-keyword-secondary">Cultural audits</strong> + <strong class="service-keyword-secondary">competitor analysis</strong> based on local buyer behavior</li>
+                <li><strong class="service-keyword-primary">Storytelling</strong> — Messaging + <strong class="service-keyword-secondary">channel strategy</strong> aligned with Japan’s high-trust market dynamics</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -232,9 +232,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-2" hidden>
               <ul class="service-accordion-list">
-                <li><strong>Resonate</strong> — Website, landing page, and product copy that feels natural &amp; persuasive</li>
-                <li><strong>Unify</strong> — Bilingual brand guidelines + messaging playbooks for global ⇄ JP alignment</li>
-                <li><strong>Perform</strong> — SEO content, PR, ads, and social campaigns adapted for Japan</li>
+                <li><strong class="service-keyword-primary">Resonate</strong> — <strong class="service-keyword-secondary">Website, landing page, and product copy</strong> that feels natural &amp; persuasive</li>
+                <li><strong class="service-keyword-primary">Unify</strong> — <strong class="service-keyword-secondary">Bilingual brand guidelines</strong> + messaging playbooks for global ⇄ JP alignment</li>
+                <li><strong class="service-keyword-primary">Perform</strong> — <strong class="service-keyword-secondary">SEO content, PR, ads, and social campaigns</strong> adapted for Japan</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -251,9 +251,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-3" hidden>
               <ul class="service-accordion-list">
-                <li><strong>Connect</strong> — EN ⇄ JP interpreting for investor meetings, community engagement, and client negotiations</li>
-                <li><strong>Engage</strong> — Event scripting, bilingual MC support, and local staff/vendor coordination</li>
-                <li><strong>Activate</strong> — On-the-ground brand activations, outreach, and live presence that build trust with Japanese audiences</li>
+                <li><strong class="service-keyword-primary">Connect</strong> — <strong class="service-keyword-secondary">EN ⇄ JP interpreting</strong> for investor meetings, community engagement, and client negotiations</li>
+                <li><strong class="service-keyword-primary">Engage</strong> — Event scripting, bilingual MC support, and local staff/vendor coordination</li>
+                <li><strong class="service-keyword-primary">Activate</strong> — On-the-ground brand activations, outreach, and live presence that build trust with Japanese audiences</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -262,7 +262,7 @@
             <button class="service-accordion-header" type="button" aria-expanded="false" aria-controls="service-panel-4">
               <span class="service-accordion-summary">
                 <i class="bi bi-signpost-2-fill icon" aria-hidden="true"></i>
-                <span class="service-accordion-title">User Research &amp; Market Insight</span>
+                <span class="service-accordion-title">User Research &amp; Japanese Market Insight</span>
               </span>
               <span class="service-accordion-indicator" aria-hidden="true">
                 <i class="bi bi-chevron-down"></i>
@@ -270,9 +270,9 @@
             </button>
             <div class="service-accordion-content" id="service-panel-4" hidden>
               <ul class="service-accordion-list">
-                <li><strong>Understand</strong> — Build Japanese-specific customer and stakeholder personas reflecting real behaviors and decision-making styles</li>
-                <li><strong>Listen</strong> — Bilingual interviews, moderated sessions, and usability testing</li>
-                <li><strong>Map</strong> — Research synthesis and cultural insight mapping to guide strategy</li>
+                <li><strong class="service-keyword-primary">Understand</strong> — Build <strong class="service-keyword-secondary">Japanese-specific personas</strong> reflecting real behaviors and decision-making styles</li>
+                <li><strong class="service-keyword-primary">Listen</strong> — Bilingual interviews, moderated sessions, and <strong class="service-keyword-secondary">usability testing</strong></li>
+                <li><strong class="service-keyword-primary">Map</strong> — Research synthesis and cultural <strong class="service-keyword-secondary">insight mapping</strong> to guide strategy</li>
               </ul>
             </div>
           </div><!-- End Service Item -->


### PR DESCRIPTION
## Summary
- refresh the Services accordion copy to match the latest strategy, localization, activation, and research offerings
- introduce scoped typography styles that keep lead keywords black while highlighting supporting phrases in brand blue
- adjust the Services tagline styling so the sentence appears in bold Atlas Grotesk at the requested size directly beneath the section underline

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68cfe5757594832297c8888a75061d55