### PR TITLE
Update services copy styling and highlights

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1566,7 +1566,7 @@ section,
 
 .services .service-accordion-list .service-keyword-secondary {
   font-weight: 700;
-  color: #667A90;
+  color: #DEA193;
 }
 
 @keyframes accordionFade {

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
             <div class="service-accordion-content" id="service-panel-2" hidden>
               <ul class="service-accordion-list">
                 <li><strong class="service-keyword-primary">Resonate</strong> — <strong class="service-keyword-secondary">Website, landing page, and product copy</strong> that feels natural &amp; persuasive</li>
-                <li><strong class="service-keyword-primary">Unify</strong> — <strong class="service-keyword-secondary">Bilingual brand guidelines</strong> + messaging playbooks for global ⇄ JP alignment</li>
+                <li><strong class="service-keyword-primary">Unify</strong> — <strong class="service-keyword-secondary">Bilingual brand guidelines</strong> for global ⇄ JP alignment</li>
                 <li><strong class="service-keyword-primary">Perform</strong> — <strong class="service-keyword-secondary">SEO content, PR, ads, and social campaigns</strong> adapted for Japan</li>
               </ul>
             </div>
@@ -252,8 +252,8 @@
             <div class="service-accordion-content" id="service-panel-3" hidden>
               <ul class="service-accordion-list">
                 <li><strong class="service-keyword-primary">Connect</strong> — <strong class="service-keyword-secondary">EN ⇄ JP interpreting</strong> for investor meetings, community engagement, and client negotiations</li>
-                <li><strong class="service-keyword-primary">Engage</strong> — Event scripting, bilingual MC support, and local staff/vendor coordination</li>
-                <li><strong class="service-keyword-primary">Activate</strong> — On-the-ground brand activations, outreach, and live presence that build trust with Japanese audiences</li>
+                <li><strong class="service-keyword-primary">Engage</strong> — Event scripting, <strong class="service-keyword-secondary">bilingual MC support</strong>, and local staff/vendor coordination</li>
+                <li><strong class="service-keyword-primary">Activate</strong> — On-the-ground <strong class="service-keyword-secondary">brand activations</strong>, outreach, and live presence that build trust with Japanese audiences</li>
               </ul>
             </div>
           </div><!-- End Service Item -->
@@ -271,7 +271,7 @@
             <div class="service-accordion-content" id="service-panel-4" hidden>
               <ul class="service-accordion-list">
                 <li><strong class="service-keyword-primary">Understand</strong> — Build <strong class="service-keyword-secondary">Japanese-specific personas</strong> reflecting real behaviors and decision-making styles</li>
-                <li><strong class="service-keyword-primary">Listen</strong> — Bilingual interviews, moderated sessions, and <strong class="service-keyword-secondary">usability testing</strong></li>
+                <li><strong class="service-keyword-primary">Listen</strong> — <strong class="service-keyword-secondary">Bilingual interviews</strong>, moderated sessions, and <strong class="service-keyword-secondary">usability testing</strong></li>
                 <li><strong class="service-keyword-primary">Map</strong> — Research synthesis and cultural <strong class="service-keyword-secondary">insight mapping</strong> to guide strategy</li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
- refresh Services section bullets with updated emphasis and localized copy
- switch highlighted keyword styling to use brand pink while keeping lead keywords black

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d085eff0588322a7d42e4fa5bd6de0