### PR TITLE
Add responsive image layout to events section

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -977,6 +977,29 @@ section,
   margin-bottom: 3rem;
 }
 
+.events .events-wrapper .events-block .events-intro {
+  margin-bottom: 3rem;
+}
+
+.events .events-wrapper .events-block .events-image {
+  display: flex;
+  justify-content: center;
+}
+
+.events .events-wrapper .events-block .events-image img {
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+@media (min-width: 992px) {
+  .events .events-wrapper .events-block .events-image {
+    justify-content: flex-end;
+  }
+}
+
 .events .events-wrapper .events-block:last-child {
   margin-bottom: 0;
 }
@@ -1074,6 +1097,10 @@ section,
 }
 
 @media (max-width: 992px) {
+  .events .events-wrapper .events-block .events-intro {
+    margin-bottom: 2rem;
+  }
+
   .events .events-wrapper .events-block h2 {
     font-size: 2rem;
   }

--- a/index.html
+++ b/index.html
@@ -443,8 +443,19 @@
           <div class="col-12">
             <div class="events-wrapper">
               <div class="events-block" data-aos="fade-up">
-                <h2>Upcoming Events</h2>
-                <p class="lead">Dedicated to fostering inclusive spaces, these events focus on meaningful connections, cultural exchange, and shared learning experiences. Stay tuned for opportunities to engage, grow, and connect!</p>
+                <div class="row gy-4 align-items-center events-intro">
+                  <div class="col-lg-7">
+                    <div class="events-content">
+                      <h2>Upcoming Events</h2>
+                      <p class="lead">Dedicated to fostering inclusive spaces, these events focus on meaningful connections, cultural exchange, and shared learning experiences. Stay tuned for opportunities to engage, grow, and connect!</p>
+                    </div>
+                  </div>
+                  <div class="col-lg-5">
+                    <div class="events-image text-center text-lg-end">
+                      <img src="eventphoto_1.jpg" class="img-fluid" alt="Guests connecting during an event">
+                    </div>
+                  </div>
+                </div>
 
                 <!--
                 <div class="timeline">


### PR DESCRIPTION
## Summary
- add a responsive two-column layout for the events introduction to pair the text with the eventphoto_1 image
- extend the events section styling to format the new image and preserve spacing on desktop and mobile

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1f4d2f7948322888c859b9d0387a9