### PR TITLE
Refine hero layout and styling

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -707,6 +707,7 @@ section,
   padding: 80px 0;
   position: relative;
   overflow: hidden;
+  text-align: left;
 }
 
 .hero .content h2 {
@@ -731,7 +732,10 @@ section,
 .hero .cta-buttons {
   display: flex;
   gap: 1rem;
-  margin-bottom: 3rem;
+  margin-bottom: 0;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-wrap: wrap;
 }
 
 @media (max-width: 576px) {
@@ -743,7 +747,8 @@ section,
 .hero .cta-buttons .btn {
   padding: 0.8rem 2rem;
   font-size: 1rem;
-  font-weight: 500;
+  font-weight: 700;
+  font-family: 'Roboto', system-ui, sans-serif;
   border-radius: 50px;
   transition: all 0.3s ease;
 }
@@ -781,27 +786,13 @@ section,
   z-index: 1;
 }
 
-.hero .profile-line {
-  gap: 1rem;
-  flex-wrap: wrap;
-  margin-bottom: 1.5rem;
-}
-
-.hero .profile-avatar {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
-}
-
 .hero .profile-line-text {
-  font-family: 'Open Sans', sans-serif;
-  font-size: 17.5px;
-  line-height: 1.5;
+  font-family: 'Merriweather', serif, sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.6;
   color: var(--default-color);
-  flex: 1 1 220px;
+  margin-bottom: 2rem;
 }
 
 .hero .hero-shapes {
@@ -831,8 +822,8 @@ section,
   width: 220px;
   height: 220px;
   background-color: color-mix(in srgb, var(--heading-color), transparent 60%);
-  bottom: -100px;
-  right: -100px;
+  top: 140px;
+  right: -60px;
   animation: morphShape 20s linear infinite reverse;
 }
 
@@ -874,16 +865,13 @@ section,
 
 @media (max-width: 991px) {
   .hero {
-    text-align: center;
+    text-align: left;
     padding: 60px 0;
   }
 
   .hero .cta-buttons {
-    justify-content: center;
-  }
-
-  .hero .profile-line {
-    justify-content: center;
+    justify-content: flex-start;
+    align-items: flex-start;
   }
 
   #heroexit .hero-image {

--- a/index.html
+++ b/index.html
@@ -168,15 +168,12 @@
 
         <div class="row align-items-center content position-relative">
           <div class="col-lg-10 col-xl-8" data-aos="fade-up" data-aos-delay="200">
-            <div class="profile-line d-flex align-items-center">
-              <img src="assets/img/profile/headshot-with-art.png" width="100" height="100" alt="Miki Toyota headshot with artistic background" class="profile-avatar">
-              <p class="profile-line-text mb-0">Miki Toyota, Your strategist. Your copywriter. Your Japan bridge.</p>
-            </div>
             <h2>Grow your impact in Japan without the guesswork.</h2>
             <p class="lead">Japan marketing &amp; localization with strategy, execution, and clarity. Expand with confidence and build trust from day one.</p>
+            <p class="profile-line-text">Miki Toyota, Your strategist. Your copywriter. Your Japan bridge.</p>
             <div class="cta-buttons" data-aos="fade-up" data-aos-delay="300">
-              <a href="#portfolio" class="btn btn-primary">Explore Services</a>
-              <a href="#heroexit" class="btn btn-outline">Let's Connect</a>
+              <a href="#portfolio" class="btn btn-primary">View My Work</a>
+              <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- align hero copy and calls-to-action to the left for a cleaner layout
- reposition the profile line text beneath the subhead with updated typography and refreshed CTA labels
- adjust hero decorative shapes and spacing to better integrate the section with the rest of the page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2122386d48322b2918258baec978f