### PR TITLE
Update hero messaging and layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -723,10 +723,45 @@ section,
   }
 }
 
+.hero .hero-headline-line {
+  display: block;
+}
+
+.hero .hero-headline-line-1 {
+  white-space: nowrap;
+}
+
 .hero .content .lead {
   font-size: 1.15625rem;
-  margin-bottom: 2rem;
+  margin: 0;
   color: color-mix(in srgb, var(--default-color), transparent 20%);
+}
+
+.hero .hero-subhead-row {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.75rem;
+}
+
+.hero .hero-subhead-row .lead {
+  flex: 1 1 280px;
+}
+
+.hero .hero-subhead-row .cta-buttons {
+  flex: 0 0 auto;
+}
+
+.hero .hero-subhead-accent {
+  color: var(--accent-color);
+  font-weight: 700;
+}
+
+@media (min-width: 992px) {
+  .hero .hero-subhead-row .lead {
+    white-space: nowrap;
+  }
 }
 
 .hero .cta-buttons {
@@ -786,13 +821,32 @@ section,
   z-index: 1;
 }
 
+.hero .hero-profile {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.hero .hero-profile-img {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
 .hero .profile-line-text {
-  font-family: 'Merriweather', serif, sans-serif;
+  font-family: 'Open Sans', sans-serif;
   font-size: 16px;
-  font-weight: 700;
+  font-weight: 400;
   line-height: 1.6;
   color: var(--default-color);
-  margin-bottom: 2rem;
+  margin: 0;
+}
+
+.hero .profile-line-text strong {
+  font-weight: 700;
 }
 
 .hero .hero-shapes {

--- a/index.html
+++ b/index.html
@@ -168,12 +168,22 @@
 
         <div class="row align-items-center content position-relative">
           <div class="col-lg-10 col-xl-8" data-aos="fade-up" data-aos-delay="200">
-            <h2>Grow your impact in Japan without the guesswork.</h2>
-            <p class="lead">Japan marketing &amp; localization with strategy, execution, and clarity. Expand with confidence and build trust from day one.</p>
-            <p class="profile-line-text">Miki Toyota, Your strategist. Your copywriter. Your Japan bridge.</p>
-            <div class="cta-buttons" data-aos="fade-up" data-aos-delay="300">
-              <a href="#portfolio" class="btn btn-primary">View My Work</a>
-              <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
+            <h2 class="hero-headline">
+              <span class="hero-headline-line hero-headline-line-1">Grow your impact in Japan</span>
+              <span class="hero-headline-line hero-headline-line-2">without the guesswork.</span>
+            </h2>
+            <div class="hero-subhead-row">
+              <p class="lead">
+                <span class="hero-subhead-accent">Japan marketing &amp; localization</span>: from bilingual strategy to execution, all in one.
+              </p>
+              <div class="cta-buttons" data-aos="fade-up" data-aos-delay="300">
+                <a href="#portfolio" class="btn btn-primary">View My Work</a>
+                <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
+              </div>
+            </div>
+            <div class="hero-profile" data-aos="fade-up" data-aos-delay="350">
+              <img src="assets/img/profile/headshot-with-art.png" class="hero-profile-img" alt="Portrait of Miki Toyota" width="100" height="100">
+              <p class="profile-line-text">Miki Toyota, <strong>Your strategist. Your copywriter. Your Japan bridge.</strong></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restructure the hero headline into two fixed lines to emphasize the message
- refresh the subhead with accent-highlighted copy and reposition the CTA buttons alongside it
- add the new circular profile image with updated typography for the profile line beneath the subhead

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68d21c2371248322a1ee76be2529350b