### PR TITLE
Adjust hero headline layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -711,7 +711,7 @@ section,
 }
 
 .hero .content h2 {
-  font-size: 5.25rem;
+  font-size: 5.125rem;
   font-weight: 700;
   line-height: 1.2;
   margin-bottom: 1.5rem;
@@ -719,16 +719,31 @@ section,
 
 @media (max-width: 991px) {
   .hero .content h2 {
-    font-size: 3rem;
+    font-size: 2.9375rem;
   }
 }
 
 .hero .hero-headline-line {
   display: block;
+  letter-spacing: -0.01em;
 }
 
 .hero .hero-headline-line-1 {
   white-space: nowrap;
+}
+
+.hero .hero-headline-line-2 {
+  white-space: nowrap;
+}
+
+@media (max-width: 575.98px) {
+  .hero .content h2 {
+    font-size: 2.875rem;
+  }
+
+  .hero .hero-headline-line {
+    letter-spacing: -0.0125em;
+  }
 }
 
 .hero .content .lead {


### PR DESCRIPTION
## Summary
- tighten hero headline spacing and ensure both lines stay on a single line each
- slightly reduce hero headline font sizes on desktop and mobile to avoid overflow
- add responsive adjustments so the headline fits within the mobile viewport without clipping

## Testing
- `python3 -m http.server 8000`
- `playwright script (browser_container)`

------
https://chatgpt.com/codex/tasks/task_e_68d2233c8b248322b2cc4549a1407630