### PR TITLE
Refine hero layout and copy

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -711,7 +711,7 @@ section,
 }
 
 .hero .content h2 {
-  font-size: 5.25rem;
+  font-size: 5.125rem;
   font-weight: 700;
   line-height: 1.2;
   margin-bottom: 1.5rem;
@@ -719,16 +719,31 @@ section,
 
 @media (max-width: 991px) {
   .hero .content h2 {
-    font-size: 3rem;
+    font-size: 2.9375rem;
   }
 }
 
 .hero .hero-headline-line {
   display: block;
+  letter-spacing: -0.01em;
 }
 
 .hero .hero-headline-line-1 {
   white-space: nowrap;
+}
+
+.hero .hero-headline-line-2 {
+  white-space: nowrap;
+}
+
+@media (max-width: 575.98px) {
+  .hero .content h2 {
+    font-size: 2.875rem;
+  }
+
+  .hero .hero-headline-line {
+    letter-spacing: -0.0125em;
+  }
 }
 
 .hero .content .lead {
@@ -739,7 +754,7 @@ section,
 
 .hero .hero-subhead-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 1.5rem;
   flex-wrap: wrap;
   margin-bottom: 1.75rem;
@@ -753,9 +768,9 @@ section,
   flex: 0 0 auto;
 }
 
-.hero .hero-subhead-accent {
-  color: var(--accent-color);
+.hero .hero-subhead-highlight {
   font-weight: 700;
+  color: inherit;
 }
 
 @media (min-width: 992px) {
@@ -769,13 +784,16 @@ section,
   gap: 1rem;
   margin-bottom: 0;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: center;
   flex-wrap: wrap;
+  margin-left: auto;
 }
 
-@media (max-width: 576px) {
+@media (max-width: 767.98px) {
   .hero .cta-buttons {
-    flex-direction: column;
+    margin-left: 0;
+    justify-content: center;
+    width: 100%;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
             </h2>
             <div class="hero-subhead-row">
               <p class="lead">
-                <span class="hero-subhead-accent">Japan marketing &amp; localization</span>: from bilingual strategy to execution, all in one.
+                <strong class="hero-subhead-highlight">Japan marketing &amp; localization</strong>: from bilingual strategy to execution, all in one.
               </p>
               <div class="cta-buttons" data-aos="fade-up" data-aos-delay="300">
                 <a href="#portfolio" class="btn btn-primary">View My Work</a>
@@ -183,7 +183,7 @@
             </div>
             <div class="hero-profile" data-aos="fade-up" data-aos-delay="350">
               <img src="assets/img/profile/headshot-with-art.png" class="hero-profile-img" alt="Portrait of Miki Toyota" width="100" height="100">
-              <p class="profile-line-text">Miki Toyota, <strong>Your strategist. Your copywriter. Your Japan bridge.</strong></p>
+              <p class="profile-line-text">Miki Toyota | <strong>Your strategist. Your copywriter. Your Japan bridge.</strong></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- tighten hero headline spacing and ensure both lines stay on a single line each
- slightly reduce hero headline font sizes on desktop and mobile to avoid overflow
- add responsive adjustments so the headline fits within the mobile viewport without clipping
- bold the hero subhead lead-in, align CTA buttons alongside it with responsive centering, and refresh the hero profile tagline punctuation

## Testing
- Not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68d2233c8b248322b2cc4549a1407630