### PR TITLE
Adjust hero headline responsiveness and CTA alignment

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -711,38 +711,40 @@ section,
 }
 
 .hero .content h2 {
-  font-size: 5.125rem;
+  font-size: 2.75rem;
   font-weight: 700;
-  line-height: 1.2;
+  line-height: 1.25;
   margin-bottom: 1.5rem;
-}
-
-@media (max-width: 991px) {
-  .hero .content h2 {
-    font-size: 2.9375rem;
-  }
 }
 
 .hero .hero-headline-line {
   display: block;
   letter-spacing: -0.01em;
-}
-
-.hero .hero-headline-line-1 {
-  white-space: nowrap;
-}
-
-.hero .hero-headline-line-2 {
-  white-space: nowrap;
+  word-break: keep-all;
 }
 
 @media (max-width: 575.98px) {
-  .hero .content h2 {
-    font-size: 2.875rem;
-  }
-
   .hero .hero-headline-line {
     letter-spacing: -0.0125em;
+  }
+}
+
+@media (min-width: 768px) {
+  .hero .content h2 {
+    font-size: 3.625rem;
+    line-height: 1.22;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero .content h2 {
+    font-size: 5.125rem;
+    line-height: 1.15;
+  }
+
+  .hero .hero-headline-line-1,
+  .hero .hero-headline-line-2 {
+    white-space: nowrap;
   }
 }
 
@@ -754,18 +756,21 @@ section,
 
 .hero .hero-subhead-row {
   display: flex;
-  align-items: flex-start;
-  gap: 1.5rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
   margin-bottom: 1.75rem;
+  text-align: center;
 }
 
 .hero .hero-subhead-row .lead {
-  flex: 1 1 280px;
+  flex: none;
+  width: 100%;
+  max-width: 38rem;
 }
 
 .hero .hero-subhead-row .cta-buttons {
-  flex: 0 0 auto;
+  flex: none;
 }
 
 .hero .hero-subhead-highlight {
@@ -773,27 +778,50 @@ section,
   color: inherit;
 }
 
-@media (min-width: 992px) {
-  .hero .hero-subhead-row .lead {
-    white-space: nowrap;
-  }
-}
-
 .hero .cta-buttons {
   display: flex;
   gap: 1rem;
   margin-bottom: 0;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
   flex-wrap: wrap;
-  margin-left: auto;
+  margin-left: 0;
 }
 
 @media (max-width: 767.98px) {
   .hero .cta-buttons {
-    margin-left: 0;
-    justify-content: center;
     width: 100%;
+  }
+}
+
+@media (min-width: 768px) {
+  .hero .hero-subhead-row {
+    flex-direction: row;
+    align-items: center;
+    gap: 2rem;
+    text-align: left;
+    flex-wrap: wrap;
+  }
+
+  .hero .hero-subhead-row .lead {
+    flex: 1 1 auto;
+    width: auto;
+    max-width: none;
+  }
+
+  .hero .hero-subhead-row .cta-buttons {
+    flex: 0 0 auto;
+  }
+
+  .hero .cta-buttons {
+    margin-left: auto;
+    justify-content: flex-start;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero .hero-subhead-row {
+    flex-wrap: nowrap;
   }
 }
 
@@ -894,9 +922,17 @@ section,
   width: 220px;
   height: 220px;
   background-color: color-mix(in srgb, var(--heading-color), transparent 60%);
-  top: 140px;
-  right: -60px;
+  top: auto;
+  right: -40px;
+  bottom: 40px;
   animation: morphShape 20s linear infinite reverse;
+}
+
+@media (max-width: 991.98px) {
+  .hero .hero-shapes .shape-2 {
+    right: -80px;
+    bottom: 10px;
+  }
 }
 
 #heroexit .hero-image {


### PR DESCRIPTION
## Summary
- refine hero headline typography with device-specific breakpoints to keep the desktop hero copy on two lines while allowing natural wrapping on smaller viewports
- realign the hero subhead and CTA buttons so they sit on the same row for wide screens and center-stack when space is limited
- reposition the secondary hero shape beside the profile callout for improved visual balance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d228823bf8832292c5d63f65b273f4