### PR TITLE
Center hero CTAs and keep subheadline single line

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -754,23 +754,11 @@ section,
   color: color-mix(in srgb, var(--default-color), transparent 20%);
 }
 
-.hero .hero-subhead-row {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.25rem;
-  margin-bottom: 1.75rem;
-  text-align: center;
-}
-
-.hero .hero-subhead-row .lead {
-  flex: none;
+.hero .hero-subheadline {
   width: 100%;
-  max-width: 38rem;
-}
-
-.hero .hero-subhead-row .cta-buttons {
-  flex: none;
+  max-width: 42rem;
+  margin: 0 0 1.75rem;
+  text-align: left;
 }
 
 .hero .hero-subhead-highlight {
@@ -781,47 +769,31 @@ section,
 .hero .cta-buttons {
   display: flex;
   gap: 1rem;
-  margin-bottom: 0;
+  width: 100%;
+  margin: 1.25rem auto 0;
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
-  margin-left: 0;
 }
 
 @media (max-width: 767.98px) {
-  .hero .cta-buttons {
-    width: 100%;
-  }
-}
-
-@media (min-width: 768px) {
-  .hero .hero-subhead-row {
-    flex-direction: row;
-    align-items: center;
-    gap: 2rem;
-    text-align: left;
-    flex-wrap: wrap;
-  }
-
-  .hero .hero-subhead-row .lead {
-    flex: 1 1 auto;
-    width: auto;
-    max-width: none;
-  }
-
-  .hero .hero-subhead-row .cta-buttons {
-    flex: 0 0 auto;
+  .hero .hero-subheadline {
+    margin-bottom: 1.5rem;
   }
 
   .hero .cta-buttons {
-    margin-left: auto;
-    justify-content: flex-start;
+    margin-top: 1rem;
   }
 }
 
 @media (min-width: 1024px) {
-  .hero .hero-subhead-row {
-    flex-wrap: nowrap;
+  .hero .hero-subheadline {
+    max-width: none;
+    white-space: nowrap;
+  }
+
+  .hero .cta-buttons {
+    max-width: 32rem;
   }
 }
 
@@ -867,11 +839,16 @@ section,
   z-index: 1;
 }
 
+.hero .hero-main-col {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .hero .hero-profile {
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 2rem;
+  margin-bottom: 0;
 }
 
 .hero .hero-profile-img {

--- a/index.html
+++ b/index.html
@@ -167,23 +167,21 @@
         </div>
 
         <div class="row align-items-center content position-relative">
-          <div class="col-lg-10 col-xl-8" data-aos="fade-up" data-aos-delay="200">
+          <div class="col-lg-10 col-xl-8 hero-main-col" data-aos="fade-up" data-aos-delay="200">
             <h2 class="hero-headline">
               <span class="hero-headline-line hero-headline-line-1">Grow your impact in Japan</span>
               <span class="hero-headline-line hero-headline-line-2">without the guesswork.</span>
             </h2>
-            <div class="hero-subhead-row">
-              <p class="lead">
-                <strong class="hero-subhead-highlight">Japan marketing &amp; localization</strong>: from bilingual strategy to execution, all in one.
-              </p>
-              <div class="cta-buttons" data-aos="fade-up" data-aos-delay="300">
-                <a href="#portfolio" class="btn btn-primary">View My Work</a>
-                <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
-              </div>
-            </div>
+            <p class="lead hero-subheadline">
+              <strong class="hero-subhead-highlight">Japan marketing &amp; localization</strong>: from bilingual strategy to execution, all in one.
+            </p>
             <div class="hero-profile" data-aos="fade-up" data-aos-delay="350">
               <img src="assets/img/profile/headshot-with-art.png" class="hero-profile-img" alt="Portrait of Miki Toyota" width="100" height="100">
               <p class="profile-line-text">Miki Toyota | <strong>Your strategist. Your copywriter. Your Japan bridge.</strong></p>
+            </div>
+            <div class="cta-buttons" data-aos="fade-up" data-aos-delay="400">
+              <a href="#portfolio" class="btn btn-primary">View My Work</a>
+              <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- keep the hero subheadline visually aligned with the headline and lock it to a single line on desktop screens
- center the hero CTA buttons beneath the profile block with reduced spacing so the hero flows cleanly into the services section

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68d230fd3b188322a1d0735bb417dc00