### PR TITLE
Adjust hero spacing for consistent rhythm

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -704,7 +704,7 @@ section,
 # Hero Section
 --------------------------------------------------------------*/
 .hero {
-  padding: 80px 0;
+  padding: clamp(84px, 14vw, 140px) 0 clamp(40px, 6vw, 56px);
   position: relative;
   overflow: hidden;
   text-align: left;
@@ -935,7 +935,7 @@ section,
 @media (max-width: 991px) {
   .hero {
     text-align: left;
-    padding: 60px 0;
+    padding: clamp(64px, 18vw, 96px) 0 clamp(40px, 12vw, 48px);
   }
 
   .hero .cta-buttons {


### PR DESCRIPTION
## Summary
- tighten the hero section's vertical padding with clamp-based values so the CTA block transitions cleanly into the Services section without the oversized gap
- update the tablet and mobile breakpoint padding to mirror the new spacing scale and keep the hero content balanced beneath the header

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2352071388322a62c33e97435c83c