### PR TITLE
Adjust hero subheadline and CTA alignment

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -761,6 +761,13 @@ section,
   text-align: left;
 }
 
+@media (min-width: 1200px) {
+  .hero .hero-subheadline {
+    max-width: none;
+    white-space: nowrap;
+  }
+}
+
 .hero .hero-subhead-highlight {
   font-weight: 700;
   color: inherit;
@@ -769,7 +776,7 @@ section,
 .hero .cta-buttons {
   display: flex;
   gap: 1rem;
-  margin: 1.75rem 0 0;
+  margin: 1.75rem auto 0;
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- prevent the hero subheadline from wrapping on wide screens so the copy sits on a single line
- center the hero CTA buttons by giving their container automatic side margins

## Testing
- not run (static content changes)

------
https://chatgpt.com/codex/tasks/task_e_68d2357acefc8322b49d6b0016a12dc0