### PR TITLE
Center hero CTAs and tidy subheadline layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -757,8 +757,9 @@ section,
 .hero .hero-subheadline {
   width: 100%;
   max-width: 42rem;
-  margin: 0 0 1.75rem;
+  margin: 0 0 1.625rem;
   text-align: left;
+  text-wrap: balance;
 }
 
 @media (min-width: 1200px) {
@@ -776,7 +777,7 @@ section,
 .hero .cta-buttons {
   display: flex;
   gap: 1rem;
-  margin: 1.75rem auto 0;
+  margin: 1.5rem auto 0;
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
@@ -789,7 +790,15 @@ section,
 
   .hero .cta-buttons {
     width: 100%;
-    margin-top: 1.25rem;
+    margin-top: 1.5rem;
+    row-gap: 0.75rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .hero .cta-buttons {
+    flex-direction: column;
+    align-items: center;
   }
 }
 
@@ -839,7 +848,7 @@ section,
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 0;
+  margin: 1.75rem 0 0;
 }
 
 .hero .hero-profile-img {

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
         </div>
 
         <div class="row align-items-center content position-relative">
-          <div class="col-lg-10 col-xl-8" data-aos="fade-up" data-aos-delay="200">
+          <div class="col-lg-10 col-xl-10 col-xxl-8" data-aos="fade-up" data-aos-delay="200">
             <h2 class="hero-headline">
               <span class="hero-headline-line hero-headline-line-1">Grow your impact in Japan</span>
               <span class="hero-headline-line hero-headline-line-2">without the guesswork.</span>
@@ -175,13 +175,13 @@
             <p class="lead hero-subheadline">
               <strong class="hero-subhead-highlight">Japan marketing &amp; localization</strong>: from bilingual strategy to execution, all in one.
             </p>
-            <div class="hero-profile" data-aos="fade-up" data-aos-delay="350">
-              <img src="assets/img/profile/headshot-with-art.png" class="hero-profile-img" alt="Portrait of Miki Toyota" width="100" height="100">
-              <p class="profile-line-text">Miki Toyota | <strong>Your strategist. Your copywriter. Your Japan bridge.</strong></p>
-            </div>
-            <div class="cta-buttons" data-aos="fade-up" data-aos-delay="400">
+            <div class="cta-buttons" data-aos="fade-up" data-aos-delay="350">
               <a href="#portfolio" class="btn btn-primary">View My Work</a>
               <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
+            </div>
+            <div class="hero-profile" data-aos="fade-up" data-aos-delay="400">
+              <img src="assets/img/profile/headshot-with-art.png" class="hero-profile-img" alt="Portrait of Miki Toyota" width="100" height="100">
+              <p class="profile-line-text">Miki Toyota | <strong>Your strategist. Your copywriter. Your Japan bridge.</strong></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- widen the hero content column so the updated subheadline can stay on one line on large screens
- reposition the CTA buttons directly beneath the subheadline and center them for both desktop and mobile views
- tweak hero spacing and responsive styles so mobile layouts stack the CTAs cleanly and preserve visual rhythm

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2381f61c88322839b0106c21db789