### PR TITLE
Align hero CTA layout with updated subheadline styling

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -749,49 +749,59 @@ section,
 }
 
 .hero .content .lead {
-  font-size: 1.15625rem;
   margin: 0;
   color: color-mix(in srgb, var(--default-color), transparent 20%);
 }
 
-.hero .hero-subheadline {
+.hero .hero-subheadline-wrapper {
   width: 100%;
-  max-width: 42rem;
-  margin: 0 0 1.625rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1.25rem;
+  margin: 0 0 1.75rem;
+}
+
+.hero .hero-subheadline {
+  margin: 0;
+  flex: 1 1 360px;
+  max-width: min(52ch, 100%);
+  font-family: 'Open Sans', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--default-color), transparent 20%);
   text-align: left;
   text-wrap: balance;
-}
-
-@media (min-width: 1200px) {
-  .hero .hero-subheadline {
-    max-width: none;
-    white-space: nowrap;
-  }
-}
-
-.hero .hero-subhead-highlight {
-  font-weight: 700;
-  color: inherit;
 }
 
 .hero .cta-buttons {
   display: flex;
   gap: 1rem;
-  margin: 1.5rem auto 0;
-  justify-content: center;
+  justify-content: flex-end;
   align-items: center;
   flex-wrap: wrap;
+  margin: 0 0 0 auto;
+  row-gap: 0.75rem;
+}
+
+@media (max-width: 991.98px) {
+  .hero .hero-subheadline-wrapper {
+    gap: 1rem;
+  }
 }
 
 @media (max-width: 767.98px) {
-  .hero .hero-subheadline {
-    margin-bottom: 1.5rem;
+  .hero .hero-subheadline-wrapper {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
   }
 
   .hero .cta-buttons {
     width: 100%;
-    margin-top: 1.5rem;
-    row-gap: 0.75rem;
+    justify-content: center;
+    margin: 0;
   }
 }
 
@@ -879,8 +889,7 @@ section,
   z-index: 0;
 }
 
-.hero .hero-shapes .shape-1,
-.hero .hero-shapes .shape-2 {
+.hero .hero-shapes .shape-1 {
   position: absolute;
   border-radius: 30% 70% 70% 30%/30% 30% 70% 70%;
   filter: blur(0.1px);
@@ -893,23 +902,6 @@ section,
   top: -80px;
   left: -120px;
   animation: morphShape 15s linear infinite;
-}
-
-.hero .hero-shapes .shape-2 {
-  width: 220px;
-  height: 220px;
-  background-color: color-mix(in srgb, var(--heading-color), transparent 60%);
-  top: auto;
-  right: -40px;
-  bottom: 40px;
-  animation: morphShape 20s linear infinite reverse;
-}
-
-@media (max-width: 991.98px) {
-  .hero .hero-shapes .shape-2 {
-    right: -80px;
-    bottom: 10px;
-  }
 }
 
 #heroexit .hero-image {

--- a/index.html
+++ b/index.html
@@ -163,7 +163,6 @@
 
         <div class="hero-shapes" aria-hidden="true">
           <div class="shape-1"></div>
-          <div class="shape-2"></div>
         </div>
 
         <div class="row align-items-center content position-relative">
@@ -172,16 +171,18 @@
               <span class="hero-headline-line hero-headline-line-1">Grow your impact in Japan</span>
               <span class="hero-headline-line hero-headline-line-2">without the guesswork.</span>
             </h2>
-            <p class="lead hero-subheadline">
-              <strong class="hero-subhead-highlight">Japan marketing &amp; localization</strong>: from bilingual strategy to execution, all in one.
-            </p>
-            <div class="cta-buttons" data-aos="fade-up" data-aos-delay="350">
-              <a href="#portfolio" class="btn btn-primary">View My Work</a>
-              <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
+            <div class="hero-subheadline-wrapper">
+              <p class="lead hero-subheadline">
+                Japan marketing &amp; localization: from bilingual strategy to execution, all in one.
+              </p>
+              <div class="cta-buttons" data-aos="fade-up" data-aos-delay="350">
+                <a href="#portfolio" class="btn btn-primary">View My Work</a>
+                <a href="#heroexit" class="btn btn-outline">Let&rsquo;s Connect</a>
+              </div>
             </div>
             <div class="hero-profile" data-aos="fade-up" data-aos-delay="400">
               <img src="assets/img/profile/headshot-with-art.png" class="hero-profile-img" alt="Portrait of Miki Toyota" width="100" height="100">
-              <p class="profile-line-text">Miki Toyota | <strong>Your strategist. Your copywriter. Your Japan bridge.</strong></p>
+              <p class="profile-line-text">Miki Toyota | Your strategist. Your copywriter. Your Japan bridge.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the hero subheadline markup with a flex wrapper so the copy and CTA buttons share one row on wide screens and wrap cleanly on small devices
- update typography so the subheadline and profile tagline use Open Sans at normal weight and remove the redundant hero shape-2 element
- adjust hero CTA alignment rules to center the buttons beneath the subheadline on mobile breakpoints

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d23de12cb4832287e82e3cee0cdd2f